### PR TITLE
For SPR lock fix

### DIFF
--- a/include/SSystem/SComponent/c_xyz.h
+++ b/include/SSystem/SComponent/c_xyz.h
@@ -13,7 +13,7 @@
 
 struct cXyz
 {
-   private:
+   public:
     float x;
     float y;
     float z;

--- a/include/SSystem/SComponent/c_xyz.h
+++ b/include/SSystem/SComponent/c_xyz.h
@@ -11,12 +11,8 @@
 
 #include "dolphin/mtx/vec.h"
 
-struct cXyz
+struct cXyz: Vec
 {
-   public:
-    float x;
-    float y;
-    float z;
 } __attribute__( ( __packed__ ) );
 
 #endif

--- a/include/tp/dynamic_link.h
+++ b/include/tp/dynamic_link.h
@@ -27,6 +27,7 @@ namespace libtp::tp::dynamic_link
     extern "C"
     {
         bool do_link( DynamicModuleControl* dmc );
+        bool do_unlink( DynamicModuleControl* dmc );
     }
 }     // namespace libtp::tp::dynamic_link
 #endif

--- a/include/tp/dynamic_link.h
+++ b/include/tp/dynamic_link.h
@@ -27,7 +27,6 @@ namespace libtp::tp::dynamic_link
     extern "C"
     {
         bool do_link( DynamicModuleControl* dmc );
-        bool do_unlink( DynamicModuleControl* dmc );
     }
 }     // namespace libtp::tp::dynamic_link
 #endif


### PR DESCRIPTION
- Convert cXyz back to how it was previously, but with attribute packed.